### PR TITLE
Fix for g++ error: insufficient contextual information to determine type

### DIFF
--- a/episode2/step_8.cpp
+++ b/episode2/step_8.cpp
@@ -51,7 +51,8 @@ public:
         use_nothrow_awaitable
       );
 
-    if ((co_await this_coro::cancellation_state).cancelled() != cancellation_type::none)
+    auto cs = co_await this_coro::cancellation_state;
+    if (cs.cancelled() != cancellation_type::none)
     {
       co_return std::string();
     }


### PR DESCRIPTION
The following error stops the build for episode2/step_8.cpp when using the g++ compiler:

```
~/talking-async/episode2$ ASIO_ROOT=../../asio/asio make
g++ -std=c++20 -Wall -Wextra -fno-inline -I../../asio/asio/include -g -DASIO_ENABLE_HANDLER_TRACKING    step_8.cpp   -o step_8
step_8.cpp: In member function ‘asio::awaitable<std::__cxx11::basic_string<char> > message_reader<Stream>::read_message()’:
step_8.cpp:54:10: error: insufficient contextual information to determine type
   54 |     if ((co_await this_coro::cancellation_state).cancelled() != cancellation_type::none)
      |         ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
step_8.cpp:54:50: error: expected ‘)’ before ‘cancelled’
   54 |     if ((co_await this_coro::cancellation_state).cancelled() != cancellation_type::none)
      |                                                  ^~~~~~~~~
step_8.cpp:54:8: note: to match this ‘(’
   54 |     if ((co_await this_coro::cancellation_state).cancelled() != cancellation_type::none)
      |        ^
make: *** [<builtin>: step_8] Error 1
```
I'm using the default g++ version for Ubuntu LTS 22.04:
```
~/talking-async/episode2$ g++ --version
g++ (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
I've also tried the g++-12 compiler (version 12.1.0 I think) with the same problem.
Clang-14 has no problem with the code, it compiles it just fine.

I took the solution from the example in the comment in header file include/asio/this_coro.hpp from the Asio library.
